### PR TITLE
PHIOS-6835 [Memory Leak] Long trips cause mapping layer to leak memory

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -914,9 +914,9 @@ private class InnerWebSocket: Hashable {
             }
         }
     }
-    @inline(__always) func fire(_ block: ()->()){
+    @inline(__always) func fire(_ block: @escaping ()->()){
         if let queue = eventQueue {
-            queue.sync {
+            queue.async {
                 block()
             }
         } else {


### PR DESCRIPTION
- changed schedules the external block to async due to execution of them can take a long time. As result, some messages are stuck in memory.

https://1mojio.atlassian.net/browse/PHIOS-6835